### PR TITLE
fix: #55 commit status icon is incorrect

### DIFF
--- a/html/commitItem.html
+++ b/html/commitItem.html
@@ -35,11 +35,19 @@
                 <details
                     class="commit-build-statuses details-overlay details-reset js-dropdown-details hx_dropdown-fullscreen"
                     data-deferred-details-content-url="#" id="statusDetails">
-                    <summary class="color-fg-success">
+                    <summary class="color-fg-success commit-status-success">
                         <svg aria-label="1 / 1 checks OK" role="img" height="16" viewBox="0 0 16 16" version="1.1"
                             width="16" data-view-component="true" class="octicon octicon-check">
                             <path fill-rule="evenodd"
                                 d="M13.78 4.22a.75.75 0 010 1.06l-7.25 7.25a.75.75 0 01-1.06 0L2.22 9.28a.75.75 0 011.06-1.06L6 10.94l6.72-6.72a.75.75 0 011.06 0z">
+                            </path>
+                        </svg>
+                    </summary>
+                    <summary class="color-fg-danger commit-status-failure">
+                        <svg aria-label="0 / 1 checks OK" role="img" height="16" viewBox="0 0 16 16" version="1.1"
+                            width="16" data-view-component="true" class="octicon octicon-x">
+                            <path
+                                d="M3.72 3.72a.75.75 0 0 1 1.06 0L8 6.94l3.22-3.22a.749.749 0 0 1 1.275.326.749.749 0 0 1-.215.734L9.06 8l3.22 3.22a.749.749 0 0 1-.326 1.275.749.749 0 0 1-.734-.215L8 9.06l-3.22 3.22a.751.751 0 0 1-1.042-.018.751.751 0 0 1-.018-1.042L6.94 8 3.72 4.78a.75.75 0 0 1 0-1.06Z">
                             </path>
                         </svg>
                     </summary>

--- a/js/showCommits.js
+++ b/js/showCommits.js
@@ -80,6 +80,9 @@ async function getCommitDetails(repoOwner, repoName, commits, allCommits) {
                     login
                     avatarUrl
                   }
+                },
+                statusCheckRollup {
+                  state
                 }
               }
             }`;
@@ -118,6 +121,7 @@ async function getCommitDetails(repoOwner, repoName, commits, allCommits) {
     commits[i].additions = commitDetails['commit' + i].additions;
     commits[i].deletions = commitDetails['commit' + i].deletions;
     commits[i].author = commitDetails['commit' + i].author.name;
+    commits[i].statusCheckRollup = commitDetails['commit' + i].statusCheckRollup?.state;
     if (commitDetails['commit' + i].author.user != null) {
       commits[i].authorAvatar = commitDetails['commit' + i].author.user.avatarUrl;
       commits[i].authorLogin = commitDetails['commit' + i].author.user.login;
@@ -138,6 +142,7 @@ async function getCommitDetails(repoOwner, repoName, commits, allCommits) {
         target.authorLogin = commit.authorLogin;
         target.hasUserData = commit.hasUserData;
         target.parents = commit.parents;
+        target.statusCheckRollup = commit.statusCheckRollup;
       }
     }
   }
@@ -191,6 +196,13 @@ async function showCommits(commits, branchNames, allCommits, heads, pageNo, allB
       newCommitItem.querySelector("#commitTreeLink").setAttribute("href", "/" + repoOwner + "/" + repoName + "/tree/" + commit.oid);
       newCommitItem.querySelector("#commitLink").innerHTML = commit.oid.substring(0, 7);
       newCommitItem.querySelector("#statusDetails").setAttribute("data-deferred-details-content-url", "/" + repoOwner + "/" + repoName + "/commit/" + commit.oid + "/status-details");
+      if (commit.statusCheckRollup == "SUCCESS") {
+        newCommitItem.querySelector("#statusDetails .commit-status-failure").remove();
+      } else if (commit.statusCheckRollup == "FAILURE") {
+        newCommitItem.querySelector("#statusDetails .commit-status-success").remove();
+      } else {
+        newCommitItem.querySelector("#statusDetails").remove();
+      }
       newCommitItem.querySelector("#viewAllCommits").innerHTML = commit.authorLogin;
       newCommitItem.querySelector("#relativeTime").innerText = relativeTime(commit.committedDate);
       if (commit.hasUserData) {


### PR DESCRIPTION
Fix the issue "Commit status icon incorrect #55". The icon was always "Success", whereas the pipeline could be "Failure" or not exist at all.

_Previously:_
![image](https://github.com/NirmalScaria/le-git-graph/assets/37533818/405d1b38-46bc-4c75-9ef1-3e94ee79cc13)

_Now:_
![image](https://github.com/NirmalScaria/le-git-graph/assets/37533818/16f0b402-32b0-49ab-9b59-d83f9521fabb)

