### PR TITLE
Bug Fix: Preventing Cutoff of Graph on the Left Side 

### DIFF
--- a/js/drawGraph.js
+++ b/js/drawGraph.js
@@ -1,3 +1,6 @@
+// Maintaining a global variable storing the width of the svgContainer Element
+var maxX = 100;
+
 // Draws a curve between two given [commit] points
 async function drawCurve(container, startx, starty, endx, endy, color) {
   var firstLineEndY = starty + ((endy - starty - 40) / 2);
@@ -206,7 +209,6 @@ var commitDictGlobal;
 
 // Draws the graph into the graphSvg element. (Where the graph is supposed to be drawn)
 async function drawGraph(commits, commitDict) {
-  commitDictGlobal = commitDict;
   // Taking  the heights of the actual commit listings, so that the
   // commit dots (points) can be placed in the correct vertical position.
   var commitsContainer = document.getElementById("commits-container");
@@ -304,6 +306,9 @@ async function drawGraph(commits, commitDict) {
         var nextx = 30 + (14 * (indexArray[i + 1].indexOf(thisLineIndex)));
         var nexty = document.querySelectorAll('[circlesha="' + commits[i + 1].oid + '"]')[0].cy.baseVal.value;
         drawCurve(commitsGraphContainer, thisx, thisy, nextx, nexty, lineColors[thisLineIndex]);
+        // Compairing the last container width to the new lines drawn's X coordinate
+        // Using the larger of the two as the new width for the container
+        maxX = Math.max(thisx,maxX);
       }
     }
   }
@@ -327,6 +332,15 @@ async function drawGraph(commits, commitDict) {
       }
     });
   });
+  // Only updating width when it has crossed the min-width of 100
+  if(maxX > 100){
+    // Providing space for 13 lines at a time
+    // Any more than that can hamper the UI of the screen
+    maxX = Math.min(maxX,198)
+    // Updating the width of the svgContainer Element
+    var svgContainer = document.querySelector('#graphSvg');
+    svgContainer.style.width = maxX;
+  }
 }
 
 // Get the vertical and horizontal position (center)

--- a/js/drawGraph.js
+++ b/js/drawGraph.js
@@ -209,6 +209,7 @@ var commitDictGlobal;
 
 // Draws the graph into the graphSvg element. (Where the graph is supposed to be drawn)
 async function drawGraph(commits, commitDict) {
+  commitDictGlobal = commitDict;
   // Taking  the heights of the actual commit listings, so that the
   // commit dots (points) can be placed in the correct vertical position.
   var commitsContainer = document.getElementById("commits-container");


### PR DESCRIPTION
Bug Fix for issue #79 
This is a commit to help increase support for larger number of lines to run without any one getting cut in a graph.

Original Behavior: 
<img width="959" alt="Screenshot 2024-10-05 at 1 40 39 PM" src="https://github.com/user-attachments/assets/fd71b063-5c3d-4c95-b533-6b7a88fbf062">

Graph gets cut off on the left side ( see yellow ). Worsening User experience

Updated Behavior:
<img width="1137" alt="Screenshot 2024-10-05 at 2 50 50 PM" src="https://github.com/user-attachments/assets/4fec6c4a-9a2b-42a0-9a02-4f4975d29e89">

Width of the graph container dynamically changes based on the number of lines.

To fix the bug, a new variable named maxX was added and it was updated based on the number of lines. This was then set as the width of the graph Container div