### PR TITLE
Bug Fix: Commits page opens after navigating away Issue 54

### DIFF
--- a/js/drawGraph.js
+++ b/js/drawGraph.js
@@ -1,3 +1,6 @@
+// Maintaining a global variable storing the width of the svgContainer Element
+var maxX = 100;
+
 // Draws a curve between two given [commit] points
 async function drawCurve(container, startx, starty, endx, endy, color) {
   var firstLineEndY = starty + ((endy - starty - 40) / 2);
@@ -206,7 +209,6 @@ var commitDictGlobal;
 
 // Draws the graph into the graphSvg element. (Where the graph is supposed to be drawn)
 async function drawGraph(commits, commitDict) {
-  commitDictGlobal = commitDict;
   // Taking  the heights of the actual commit listings, so that the
   // commit dots (points) can be placed in the correct vertical position.
   var commitsContainer = document.getElementById("commits-container");
@@ -304,6 +306,9 @@ async function drawGraph(commits, commitDict) {
         var nextx = 30 + (14 * (indexArray[i + 1].indexOf(thisLineIndex)));
         var nexty = document.querySelectorAll('[circlesha="' + commits[i + 1].oid + '"]')[0].cy.baseVal.value;
         drawCurve(commitsGraphContainer, thisx, thisy, nextx, nexty, lineColors[thisLineIndex]);
+        // Compairing the last container width to the new lines drawn's X coordinate
+        // Using the larger of the two as the new width for the container
+        maxX = Math.max(thisx,maxX);
       }
     }
   }
@@ -327,6 +332,15 @@ async function drawGraph(commits, commitDict) {
       }
     });
   });
+  // Only updating width when it has crossed the min-width of 100
+  if(maxX > 100){
+    // Providing space for 13 lines at a time
+    // Any more than that can hamper the UI of the screen
+    maxX = Math.min(maxX,198)
+    // Updating the width of the svgContainer Element
+    var svgContainer = document.querySelector('#graphSvg');
+    svgContainer.style.width = maxX;
+  }
 }
 
 // Get the vertical and horizontal position (center)

--- a/js/drawGraph.js
+++ b/js/drawGraph.js
@@ -1,6 +1,3 @@
-// Maintaining a global variable storing the width of the svgContainer Element
-var maxX = 100;
-
 // Draws a curve between two given [commit] points
 async function drawCurve(container, startx, starty, endx, endy, color) {
   var firstLineEndY = starty + ((endy - starty - 40) / 2);
@@ -307,9 +304,6 @@ async function drawGraph(commits, commitDict) {
         var nextx = 30 + (14 * (indexArray[i + 1].indexOf(thisLineIndex)));
         var nexty = document.querySelectorAll('[circlesha="' + commits[i + 1].oid + '"]')[0].cy.baseVal.value;
         drawCurve(commitsGraphContainer, thisx, thisy, nextx, nexty, lineColors[thisLineIndex]);
-        // Compairing the last container width to the new lines drawn's X coordinate
-        // Using the larger of the two as the new width for the container
-        maxX = Math.max(thisx,maxX);
       }
     }
   }
@@ -333,15 +327,6 @@ async function drawGraph(commits, commitDict) {
       }
     });
   });
-  // Only updating width when it has crossed the min-width of 100
-  if(maxX > 100){
-    // Providing space for 13 lines at a time
-    // Any more than that can hamper the UI of the screen
-    maxX = Math.min(maxX,198)
-    // Updating the width of the svgContainer Element
-    var svgContainer = document.querySelector('#graphSvg');
-    svgContainer.style.width = maxX;
-  }
 }
 
 // Get the vertical and horizontal position (center)

--- a/js/drawGraph.js
+++ b/js/drawGraph.js
@@ -209,6 +209,7 @@ var commitDictGlobal;
 
 // Draws the graph into the graphSvg element. (Where the graph is supposed to be drawn)
 async function drawGraph(commits, commitDict) {
+  commitDictGlobal = commitDict;
   // Taking  the heights of the actual commit listings, so that the
   // commit dots (points) can be placed in the correct vertical position.
   var commitsContainer = document.getElementById("commits-container");

--- a/js/sortCommits.js
+++ b/js/sortCommits.js
@@ -75,6 +75,18 @@ async function sortCommits(branches, heads, allBranches) {
 
     console.log("--COMMITS FOR THIS PAGE ARE--");
     console.log(commitsObject.slice(0, 10));
-    await showCommits(commitsObject.slice(0, 10), branchNames, commits, heads, 1, allBranchNames);
-    showLegend(heads);
+    // Getting the Commits button to check the value of aria-current attribute
+    // This determines if the button is underlined or not
+
+    var parentObject = document.querySelector('[data-pjax="#js-repo-pjax-container"]').children[0];
+    var newButton = parentObject.children[1];
+    var newButtonChild = newButton.children[0];
+    // Checking for underline
+    if(newButtonChild.getAttribute("aria-current") == "page"){
+        await showCommits(commitsObject.slice(0, 10), branchNames, commits, heads, 1, allBranchNames);
+        showLegend(heads);
+    }
+    else{
+        console.log("Page Changed before rendering");
+    }
 }

--- a/js/sortCommits.js
+++ b/js/sortCommits.js
@@ -87,6 +87,6 @@ async function sortCommits(branches, heads, allBranches) {
         showLegend(heads);
     }
     else{
-        console.log("Page Changed before rendering");
+        console.log("PAGE CHANGED BEFORE COMMITS RENDER");
     }
 }


### PR DESCRIPTION
Issue #54 

Fixed the issue of "Commit Tab" opening after the user has moved to a different page. Issue was in the way the events were triggered. (See issue #54 for video)

Changes:
Added code to check if the commits button is active or not. Rendering only if the button is still selected. 

New Behaviour

https://github.com/user-attachments/assets/705da013-6721-4a07-91f1-3ac0e67c0272

