### PR TITLE
fix: #57 update custom PAT flow to set user name

### DIFF
--- a/js/addAuthorizationPrompt.js
+++ b/js/addAuthorizationPrompt.js
@@ -144,6 +144,7 @@ function proceedForAuthorization() {
         var customPATInput = document.getElementsByClassName("custom-pat-input")[0];
         var customPAT = customPATInput.value;
         storeLocalToken(customPAT);
+        storeLocalUserName("");
         var presentUrl = window.location.href;
         if (presentUrl.indexOf("?") < 0) {
             window.location.href = presentUrl + "/?page=commits";


### PR DESCRIPTION
This PR fixes #57

When we add Custom Personal Access Token it doesn't set a user name in local storage.
This makes it unable to proceed past the add authorization prompt because of the following piece of logic:
https://github.com/NirmalScaria/le-git-graph/blob/main/js/openCommitsTab.js#L52
```
if (authorizationToken == null || storedUserName == null) {
    // Prompt the user to authorize with GitHub
    await addAuthorizationPrompt("GitHub repo access is required to fetch the commits information.");
}
```

This PR solves the issue by updating the custom PAT flow to set user name to empty string so that it is no longer null.