### PR TITLE
Use <relative-time> instead of <relativetime>, fixing datetime in the tooltip

### DIFF
--- a/html/commitItem.html
+++ b/html/commitItem.html
@@ -24,9 +24,9 @@
                 <a class="commit-author user-mention" title="View all commits by ..." id="viewAllCommits">Loading</a>
 
                 committed
-                <relativetime id="relativeTime" datetime="2022-07-26T17:08:20Z" class="no-wrap"
-                    title="26 Jul 2022, 22:38 GMT+5:30">...
-                    days ago</relativetime>
+                <relative-time id="relativeTime" datetime="2022-07-26T17:08:20Z" class="no-wrap"
+                    tense="past">...
+                    days ago</relative-time>
 
             </div>
             <div class="ml-1">

--- a/js/showCommits.js
+++ b/js/showCommits.js
@@ -204,7 +204,7 @@ async function showCommits(commits, branchNames, allCommits, heads, pageNo, allB
         newCommitItem.querySelector("#statusDetails").remove();
       }
       newCommitItem.querySelector("#viewAllCommits").innerHTML = commit.authorLogin;
-      newCommitItem.querySelector("#relativeTime").innerText = relativeTime(commit.committedDate);
+      newCommitItem.querySelector("#relativeTime").setAttribute("datetime", commit.committedDate.toISOString());
       if (commit.hasUserData) {
         newCommitItem.querySelector("#avatarImage").setAttribute("src", commit.authorAvatar + "&s=40");
         newCommitItem.querySelector("#viewAllCommits").setAttribute("title", "View all commits by " + commit.authorLogin);
@@ -236,28 +236,6 @@ async function showCommits(commits, branchNames, allCommits, heads, pageNo, allB
   // )
   // resizeObserver.observe(commitsContainer);
   return;
-}
-
-// Format the date to a human friendly format
-// Like "1 day ago", "2 weeks ago", "3 months ago"
-function relativeTime(date) {
-  var now = new Date().getTime();
-  const difference = (now - date.getTime()) / 1000;
-  let output = ``;
-  if (difference < 10) {
-    output = `just now`;
-  } else if (difference < 60) {
-    output = `${Math.floor(difference)} seconds ago`;
-  } else if (difference < 3600) {
-    output = `${Math.floor(difference / 60)} minute${Math.floor(difference / 60) > 1 ? 's' : ''} ago`;
-  } else if (difference < 86400) {
-    output = `${Math.floor(difference / 3600)} hour${Math.floor(difference / 3600) > 1 ? 's' : ''} ago`;
-  } else if (difference < 2620800) {
-    output = `${Math.floor(difference / 86400) > 1 ? (Math.floor(difference / 86400) + ' days ago') : 'yesterday'}`;
-  } else {
-    output = 'on ' + date.toLocaleDateString();
-  }
-  return (output);
 }
 
 function addNextPageButton(commits, branchNames, allCommits, heads, pageNo, allBranches) {


### PR DESCRIPTION
Currently, the tooltip displays a wrong datetime, which is a hard-coded `title` attribute value.

<img width="2318" height="368" alt="before" src="https://github.com/user-attachments/assets/77ebaee9-9ef6-40a6-a979-85c7a91f68eb" />

A solution is to reuse what GitHub itself uses for commit datetime in repositories, [`<relative-time>`](https://github.com/github/relative-time-element).

<img width="2324" height="372" alt="after" src="https://github.com/user-attachments/assets/85b29ab5-52b9-4ff5-9504-fff10fa9c3cd" />

The text content of the element is formatted differently though.