### PR TITLE
fix: narrow MutationObserver scope to prevent Global Search overlay interference

### DIFF
--- a/js/addCommitsButton.js
+++ b/js/addCommitsButton.js
@@ -124,8 +124,10 @@ function addCommitsButton() {
         }
     });
 
-    // Observe document.body with subtree to catch nav replacement
-    observer.observe(document.body, { 
+    // Observe only the nav container to avoid interfering with
+    // unrelated DOM updates like GitHub's Global Search overlay
+    var observeTarget = parentObject.parentElement || parentObject;
+    observer.observe(observeTarget, { 
         childList: true,
         subtree: true
     });


### PR DESCRIPTION
## What
**Root cause**: The MutationObserver in `addCommitsButton()` watched `document.body` with `subtree: true`, causing it to fire on every DOM mutation anywhere on the page — including GitHub's Global Search / command palette overlay initialization. When the search overlay creates/modifies DOM elements, the observer's callback runs re-entrant checks against the body's mutation batches, which can race with or interfere with GitHub's dialog setup, causing the overlay to never appear.

**Fix**: Changed the observer target from `document.body` to `parentObject.parentElement || parentObject` (the `<nav>` element wrapping the repo tab bar). This scopes the observer strictly to the navigation container, so only nav-related DOM changes trigger it. Search overlay DOM mutations no longer cause any observer activity, eliminating the interference.

## Why
This change resolves the target issue or improvement.

## How to test
Verify that the project builds/runs correctly and the specific bug/improvement is addressed.

Fixes #110